### PR TITLE
Implement multi metric collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ concurrent API requests:
 ## Compile
 
 ```
-docker run --rm -v "$PWD/promdump":/promdump -w /promdump golang:1.12 go build
+docker run --rm -v "$PWD/promdump":/promdump -w /promdump golang:1.17 go build
 docker run --rm -v "$PWD/promremotewrite":/promremotewrite -w /promremotewrite golang:1.12 go build
 ```
 

--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -23,7 +23,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-const appVersion = "0.1.1"
+const appVersion = "0.1.2"
 const defaultPeriod = 7 * 24 * time.Hour // 7 days
 const defaultBatchDuration = 24 * time.Hour
 

--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -85,7 +85,7 @@ func logMetricCollectorConfig() {
 	var skip []string
 	for _, v := range collectMetrics {
 		if *out != "" && *out == v.exportName {
-			log.Fatalln(fmt.Sprintf("The output file prefix '%v' is reserved. Specify a different --out value.", v.exportName))
+			log.Fatalf("The output file prefix '%v' is reserved. Specify a different --out value.", v.exportName)
 		}
 		if v.collect {
 			collect = append(collect, v.exportName)
@@ -355,7 +355,7 @@ func main() {
 		for _, v := range collectMetrics {
 			matches, err := filepath.Glob(fmt.Sprintf("%s.[0-9][0-9][0-9][0-9][0-9]", v.exportName))
 			if err != nil {
-				log.Fatalln(fmt.Sprintf("main: checking for existing export files with file prefix %v failed with error: %v", v.exportName, err))
+				log.Fatalf("main: checking for existing export files with file prefix %v failed with error: %v", v.exportName, err)
 			}
 			if len(matches) > 0 {
 				// No error = file already exists
@@ -366,7 +366,7 @@ func main() {
 	if *out != "" {
 		matches, err := filepath.Glob(fmt.Sprintf("%s.[0-9][0-9][0-9][0-9][0-9]", *out))
 		if err != nil {
-			log.Fatalln(fmt.Sprintf("main: checking for existing export files with file prefix %v failed with error: %v", *out, err))
+			log.Fatalf("main: checking for existing export files with file prefix %v failed with error: %v", *out, err)
 		}
 		if len(matches) > 0 {
 			// No error = file already exists
@@ -375,7 +375,7 @@ func main() {
 	}
 	if len(fileConflictPrefixes) > 0 {
 		sort.Strings(fileConflictPrefixes)
-		log.Fatalln(fmt.Sprintf("main: found existing export files with file prefix(es): %v; move any existing export files aside before proceeding", strings.Join(fileConflictPrefixes, " ")))
+		log.Fatalf("main: found existing export files with file prefix(es): %v; move any existing export files aside before proceeding", strings.Join(fileConflictPrefixes, " "))
 	}
 
 	// TODO: DRY this out


### PR DESCRIPTION
Completed and (mostly) polished support for collecting multiple metrics. The utility now supports collecting a known set of Yugabyte metrics (master_export, node_export, tserver_export, cql_export (not a typo), and ysql_export), a specific custom metric, or both.

Cleaned and polished. A few opportunities to DRY out the code and some TODO items remaining but I want to get this update out the door ASAP because it's going to really simplify our Prometheus collection procedures.