### PR TITLE
Narrow scope of build action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,11 +7,13 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
+    types: [ closed ]
     branches: [ "master" ]
 
 jobs:
 
   build:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Reduce the scope of the build action on pull requests from all pull requests to just merged pull requests.