### PR TITLE
Dynamic versioning

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       working-directory: ./promdump
       run: |
         go get
-        go build -v ./...
+        go build -ldflags=" -X 'github.com/knyar/prometheus-remote-backfill/promdump/main.Version=$$(git rev-parse HEAD)' -X 'github.com/knyar/prometheus-remote-backfill/promdump/main.BuildTime=$$(date -Iseconds)'" -v ./...
 
     - name: Test promdump
       working-directory: ./promdump
@@ -33,7 +33,7 @@ jobs:
       working-directory: ./promremotewrite
       run: |
         go get
-        go build -v ./...
+        go build -ldflags=" -X 'github.com/knyar/prometheus-remote-backfill/promremotewrite/main.Version=$$(git rev-parse HEAD)' -X 'github.com/knyar/prometheus-remote-backfill/promremotewrite/main.BuildTime=$$(date -Iseconds)'" -v ./...
 
     - name: Test promremotewrite
       working-directory: ./promremotewrite

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,7 +6,7 @@ name: Tagged Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,11 +1,12 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
-name: Go
+name: Tagged Release
 
 on:
   push:
-    branches: [ "master" ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
 
@@ -21,9 +22,10 @@ jobs:
 
     - name: Build promdump
       working-directory: ./promdump
+      # github.ref_name is the tag or branch name
       run: |
         go get
-        go build -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        go build -ldflags=" -X 'main.AppVersion=${{ github.ref_name }}' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
 
     - name: Test promdump
       working-directory: ./promdump
@@ -31,9 +33,10 @@ jobs:
 
     - name: Build promremotewrite
       working-directory: ./promremotewrite
+      # github.ref_name is the tag or branch name
       run: |
         go get
-        go build -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        go build -ldflags=" -X 'main.AppVersion=${{ github.ref_name }}' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
 
     - name: Test promremotewrite
       working-directory: ./promremotewrite

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ concurrent API requests:
 ## Compile
 
 ```
-docker run --rm -v "$PWD/promdump":/promdump -w /promdump golang:1.19 go build
-docker run --rm -v "$PWD/promremotewrite":/promremotewrite -w /promremotewrite golang:1.19 go build
+docker run --rm -v "$PWD/promdump":/promdump -w /promdump golang:1.19 go build -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'"
+docker run --rm -v "$PWD/promremotewrite":/promremotewrite -w /promremotewrite golang:1.19 go build -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ series per metric name), you might need to decrease `-batch` even further.
 ## Example
 
 Dump all data of `node_filesystem_free` metric for the last year, issuing a
-separate query for each 12hrs of data, storing 24hrs worth of data in a each
+separate query for each 12hrs of data, storing 24hrs worth of data in each
 file:
 
     promdump -url=http://localhost:9090 \

--- a/README.md
+++ b/README.md
@@ -43,8 +43,16 @@ concurrent API requests:
 ## Compile
 
 ```
-docker run --rm -v "$PWD/promdump":/promdump -w /promdump golang:1.19 go build -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'"
-docker run --rm -v "$PWD/promremotewrite":/promremotewrite -w /promremotewrite golang:1.19 go build -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'"
+docker run --rm \
+  -v "$PWD/promdump":/promdump \
+  -w /promdump golang:1.19 \
+  go build \
+  -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'"
+docker run --rm \
+  -v "$PWD/promremotewrite":/promremotewrite \
+  -w /promremotewrite golang:1.19 \
+  go build \
+  -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'"
 ```
 
 ## License

--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -26,7 +26,6 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-const appVersion = "0.1.4"
 const defaultPeriod = 7 * 24 * time.Hour // 7 days
 const defaultBatchDuration = 24 * time.Hour
 
@@ -61,6 +60,7 @@ var (
 		"ysql": {exportName: "ysql_export", collect: true, isDefault: true},
 	}
 
+	AppVersion = "DEV BUILD"
 	CommitHash = "POPULATED_BY_BUILD"
 	BuildTime  = "POPULATED_BY_BUILD"
 )
@@ -323,12 +323,14 @@ func hasConflictingFiles(filename string) (bool, error) {
 func main() {
 	flag.Parse()
 
+	verString := fmt.Sprintf("promdump version %v from commit %v built %v\n", AppVersion, CommitHash, BuildTime)
+
 	if *version {
-		fmt.Printf("promdump version %v from commit %v built %v\n", appVersion, CommitHash, BuildTime)
+		fmt.Printf(verString)
 		os.Exit(0)
 	}
 
-	log.Printf("Starting promdump version %v\n", appVersion)
+	log.Printf(verString)
 
 	if flag.NArg() > 0 {
 		log.Fatalf("Too many arguments: %v. Check for typos.", strings.Join(flag.Args(), " "))

--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-const appVersion = "0.1.3"
+const appVersion = "0.1.4"
 const defaultPeriod = 7 * 24 * time.Hour // 7 days
 const defaultBatchDuration = 24 * time.Hour
 
@@ -60,6 +60,9 @@ var (
 		"ycql": {exportName: "cql_export", collect: true, isDefault: true},
 		"ysql": {exportName: "ysql_export", collect: true, isDefault: true},
 	}
+
+	CommitHash = "POPULATED_BY_BUILD"
+	BuildTime  = "POPULATED_BY_BUILD"
 )
 
 func init() {
@@ -321,7 +324,7 @@ func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Printf("promdump version %v\n", appVersion)
+		fmt.Printf("promdump version %v from commit %v built %v\n", appVersion, CommitHash, BuildTime)
 		os.Exit(0)
 	}
 

--- a/promremotewrite/promremotewrite.go
+++ b/promremotewrite/promremotewrite.go
@@ -26,8 +26,6 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 )
 
-const appVersion = "0.1.1"
-
 var (
 	version      = flag.Bool("version", false, "prints the promdump version and exits")
 	writeURL     = flag.String("url", "", "URL for remote write endpoint")
@@ -35,6 +33,7 @@ var (
 	batchSize    = flag.Uint("batch_size", 100000, "number of samples per request")
 	concurrency  = flag.Uint("concurrency", 1, "number of influxdb writers")
 
+	AppVersion = "DEV BUILD"
 	CommitHash = "POPULATED_BY_BUILD"
 	BuildTime  = "POPULATED_BY_BUILD"
 )
@@ -133,12 +132,14 @@ func write(client *http.Client, req *prompb.WriteRequest) error {
 func main() {
 	flag.Parse()
 
+	verString := fmt.Sprintf("promremotewrite version %v from commit %v built %v\n", AppVersion, CommitHash, BuildTime)
+
 	if *version {
-		fmt.Printf("promremotewrite version %v\n", appVersion)
+		fmt.Printf(verString)
 		os.Exit(0)
 	}
 
-	log.Printf("Starting promremotewrite version %v\n", appVersion)
+	log.Printf(verString)
 
 	if *writeURL == "" {
 		log.Fatalln("Please specify --url")

--- a/promremotewrite/promremotewrite.go
+++ b/promremotewrite/promremotewrite.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 )
 
-const appVersion = "0.1.0"
+const appVersion = "0.1.1"
 
 var (
 	version      = flag.Bool("version", false, "prints the promdump version and exits")
@@ -34,6 +34,9 @@ var (
 	writeTimeout = flag.Duration("write_timeout", 5*time.Minute, "write timeout")
 	batchSize    = flag.Uint("batch_size", 100000, "number of samples per request")
 	concurrency  = flag.Uint("concurrency", 1, "number of influxdb writers")
+
+	CommitHash = "POPULATED_BY_BUILD"
+	BuildTime  = "POPULATED_BY_BUILD"
 )
 
 // converts a slice of SampleStream messages into remote write requests and sends them into the channel.


### PR DESCRIPTION
Implement dynamic versioning based on GitHub actions for both `promdump` and `promremotewrite`. This is similar to the dynamic versioning used in the `yb-tools` repo but uses GitHub actions instead of `make`.

For pushes to the master branch, a GitHub action will be triggered that fills in the new variables `CommitHash` and `BuildTime` using the go linker flag `-ldflags`. Such builds will retain the `AppVersion` value in the code which is `DEV BUILD`.

If a new tag matching a sematic version number is pushed, the `tag.yml` action will similarly fill in the `CommitHash` and `BuildTime` variables. In addition, it will also fill in `AppVersion` with the corresponding git tag.

Finally, the action uploads the resulting artifacts to GitHub and makes them available to download from the Actions tab in the GitHub UI. For now, these artifacts need to be downloaded manually and attached to a release.