### PR TITLE
Implement YBA API integration

### DIFF
--- a/promdump/go.mod
+++ b/promdump/go.mod
@@ -1,14 +1,20 @@
-module github.com/knyar/prometheus-remote-backfill/promdump
+module github.com/yugabyte/prometheus-remote-backfill/promdump
 
 go 1.19
 
 require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.37.0
+	github.com/yugabyte/platform-go-client v0.0.0-20240415070755-794cd3b15b89
 )
 
 require (
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/promdump/go.sum
+++ b/promdump/go.sum
@@ -109,6 +109,7 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -195,6 +196,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/yugabyte/platform-go-client v0.0.0-20240415070755-794cd3b15b89 h1:h1r9J3GzgfpVtm7iX0z3yEA12Wg5oO04z5XEtf5ZpzA=
+github.com/yugabyte/platform-go-client v0.0.0-20240415070755-794cd3b15b89/go.mod h1:ZErtCh7Ig1QkNpWuGQ5YtaEJvD4fKdDS+iQxJfIlGMQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -276,6 +279,7 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b h1:clP8eMhB30EHdc0bd2Twtq6kgU7yl5ub2cQLSdrv1Dg=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
@@ -383,6 +387,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -461,6 +466,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -730,6 +730,13 @@ func main() {
 			}
 		}
 
+		if !*ybaTls {
+			log.Printf("Warning: Disabling TLS for YBA communication is insecure and not recommended!")
+		} else if *skipYbaHostVerification { // ybaTls is implicitly true here
+			// Only reached if TLS is enabled and skipYbaHostVerification is true
+			log.Println("Warning: Disabling YBA host verification is insecure and not recommended!")
+		}
+
 		// Create a context with the YBA API token in it to pass into functions that make YBA API calls
 		ybaCtx := context.WithValue(context.Background(),
 			ywclient.ContextAPIKeys,

--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -574,7 +574,7 @@ func getUniverseList(ctx context.Context, client *ywclient.APIClient, cUuid stri
 	defer func() {
 		err := r.Body.Close()
 		if err != nil {
-			log.Fatalf("getCustomerUuid: failed to close HTTP response body: %v", err)
+			log.Fatalf("getUniverseList: failed to close HTTP response body: %v", err)
 		}
 	}()
 	statusOK := r.StatusCode >= 200 && r.StatusCode < 300
@@ -599,7 +599,7 @@ func getUniverseByName(ctx context.Context, client *ywclient.APIClient, cUuid st
 	defer func() {
 		err := r.Body.Close()
 		if err != nil {
-			log.Fatalf("getCustomerUuid: failed to close HTTP response body: %v", err)
+			log.Fatalf("getUniverseByName: failed to close HTTP response body: %v", err)
 		}
 	}()
 	statusOK := r.StatusCode >= 200 && r.StatusCode < 300

--- a/promremotewrite/go.mod
+++ b/promremotewrite/go.mod
@@ -1,4 +1,4 @@
-module github.com/knyar/prometheus-remote-backfill/promremotewrite
+module github.com/yugabyte/prometheus-remote-backfill/promremotewrite
 
 go 1.19
 


### PR DESCRIPTION
This PR implements YBA API integration, allowing users to specify a `--yba_token` and either a `--universe_name` or `--universe_uuid`.

This should result in a decrease in the number of empty promdumps we get back (but probably a corresponding increase in the number of "help my API token isn't working" problems we see).

The major change in this commit is YBA API integration. This feature is intended to address the most common issue we see with promdump, where customers do not provide the correct `--node_prefix` value and the Yugabyte metrics don't get collected. When this happens, there has to be another round-trip with the customer to get the metrics.

Updates go.mod files to rename the module from `knyar/prometheus-remote-backfill` to `yugabyte/prometheus-remote-backfill`

Lots of changes to the flags.

* Added the `--list_universes` flag that will (along with the appropriate hostname and API token values) query the YBA API for the list of Universes, print it to the console, and exit. There's room for some kind of interactive menu here but that's for another day. 
* Added the `--universe_name` and `--universe_uuid` flags that will instruct promdump to use the YBA API to retrieve the correct node prefix from YBA.
* Marked the `--node_prefix` flag as deprecated.
* Added the `--yba_api_hostname` and `--yba_api_token` flags for specifying the values required to call the YBA API
* Added the `--yba_api_timeout`, `--yba_api_use_tls`, and `--yba_skip_host_verification` flags to control YBA API connection behaviour. Many customers are using self-signed certificates, so the ability to skip host validation is important.

The basic flow for the new functionality is that if the user has provided the `--list_universes`, `--universe_name`, `--universe_uuid`, or `--yba_token` flags, the YBA API feature will be activated.

We then validate the flags to confirm the following:
* A token has been provided.
* The user has not also provided a node prefix. This was deliberately made a fatal error to encourage a complete move to the new functionality and to avoid user confusion if the provided node prefix is ignored.
* Either a Universe name or Universe UUID has been provided but not both.
* The Universe UUID looks like a UUID.

The utility will print warnings when using insecure settings.

We create a context called `ybaCtx` that is used to pass the YBA API token to the API calls.

The `setupYBAAPI()` func is used to configure other client settings such as TLS, certificate verification, client timeouts, etc. and the resulting client handle is passed back to main.

We than call the `getCustomerUuid` func, passing in the context and client handle. This makes the API call and handles the response, returning the customer UUID. If multiple customer UUIDs are found, promdump exits with a fatal because the utility does not currently support multi-tenant environments.

If the user has asked for the list of Universes, we call the API to retrieve the full list of Universes, then pretty print the list and exit.

If the user has specified a universe by name or UUID, we call the corresponding YBA API function to retrieve a handle to the Universe response object. If the lookup fails (e.g. because there is no Universe that matches the search criterion), promdump will print the list of Universes and exit with a fatal error.

Once we have the correct universe object, we retrieve its node prefix attribute and write it into the `nodePrefix` variable.

The remainder of the process for retrieving and writing the metrics to disk is unchanged.

The custom metric functionality exposed using `--metric` and `--out` is unchanged and remains fully supported because we still need a mechanism for collecting custom metrics.