### PR TITLE
promdump: reduce default collection period and batch size.

### DIFF
--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -37,8 +37,8 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-const defaultPeriod = 7 * 24 * time.Hour // 7 days
-const defaultBatchDuration = 24 * time.Hour
+const defaultPeriod = 24 * time.Hour
+const defaultBatchDuration = 15 * time.Minute
 const defaultYbaHostname = "localhost"
 const defaultPromPort = 9090
 


### PR DESCRIPTION
The previous default collection period of 7d is far too long. After polling the team about the best default, reduced the default period to 24h.

Also reduced the default batch size to 15m.