### PR TITLE
promdump: fix spurious message about node_prefix being deprecated

### DIFF
--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -1028,7 +1028,7 @@ func main() {
 		*prefixValidation = false
 
 		logger.Println("main: Finished with YBA API")
-	} else {
+	} else if *nodePrefix != "" {
 		logger.Printf("Warning: The --node_prefix flag is deprecated. It is recommended to provide a --yba_api_token and use --universe_name or --universe_uuid instead.")
 	}
 


### PR DESCRIPTION
A missing if condition resulted in a warning about the --node_prefix flag being deprecated appearing even if the flag was not specified. This commit fixes the missing condition.