### PR TITLE
Masks passwords provided in the Prometheus URL flag --url

### DIFF
--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -1028,7 +1028,7 @@ func main() {
 		*prefixValidation = false
 
 		logger.Println("main: Finished with YBA API")
-	} else {
+	} else if *nodePrefix != "" {
 		logger.Printf("Warning: The --node_prefix flag is deprecated. It is recommended to provide a --yba_api_token and use --universe_name or --universe_uuid instead.")
 	}
 


### PR DESCRIPTION
For customers with Prometheus authentication enabled, `promdump` currently only supports specifying a username and password by providing them as part of the URL in the format http://username:password@hostname:9090.

The URL is currently printed out in the promdump logs, meaning this password will be exposed during metrics collection. This PR modifies the utility so the provided URL string is parsed into a URL object and only ever printed to the logs using `URL.Redacted()` to prevent this password exposure.