### PR TITLE
promdump: fix crash in error handling

### DIFF
--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -483,9 +483,9 @@ func exportMetric(ctx context.Context, promApi v1.API, metric string, beginTS ti
 					break batchBackoff
 				}
 
-				sleepTime, err := promRetryWait(retryCount, *promRetryDelay, *promRetryMaxBackoff, *promRetryBackoff)
-				if err != nil {
-					logger.Fatalf("exportMetric: failed to calculate retry delay: %v", err)
+				sleepTime, retryErr := promRetryWait(retryCount, *promRetryDelay, *promRetryMaxBackoff, *promRetryBackoff)
+				if retryErr != nil {
+					logger.Fatalf("exportMetric: failed to calculate retry delay: %v", retryErr)
 				}
 
 				if promErrIsFatal(err) {


### PR DESCRIPTION
The call to promRetryWait to calculate the sleep time was moved before the calls that check whether a particular error is fatal, retryable, etc.. This led to the actual error we're trying to test being masked by the error return from promRetryWait, leading to a nil error being passed into promErrIssFatal and causing a crash.

This commit changes the name of the variable holding the error return from promRetryWait in order to prevent the crash.