### PR TITLE
Disable CGO to allow the binary to run on older OSes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
       working-directory: ./promdump
       run: |
         go get
-        go build -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        CGO_ENABLED=0 go build -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
 
     - name: Test promdump
       working-directory: ./promdump

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -26,7 +26,7 @@ jobs:
       # github.ref_name is the tag or branch name
       run: |
         go get
-        go build -ldflags=" -X 'main.AppVersion=${{ github.ref_name }}' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        CGO_ENABLED=0 go build -ldflags=" -X 'main.AppVersion=${{ github.ref_name }}' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
 
     - name: Test promdump
       working-directory: ./promdump


### PR DESCRIPTION
The version of glibc used in newer golang CGO implementations is not available on older Linux versions.

Setting CGO_ENABLED=0 during build will force the go compiler to produce statically linked binaries that do not depend on CGO.