### PR TITLE
Set the linker configuration to suppress debug symbols to reduce file size

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
       working-directory: ./promdump
       run: |
         go get
-        CGO_ENABLED=0 go build -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        CGO_ENABLED=0 go build -ldflags=" -s -w -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
 
     - name: Test promdump
       working-directory: ./promdump

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,8 @@ jobs:
       working-directory: ./promdump
       run: |
         go get
-        CGO_ENABLED=0 go build -ldflags=" -s -w -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        CGO_ENABLED=0 go build -ldflags=" -s -w -X 'main.SymbolStatus=STRIPPED' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        CGO_ENABLED=0 go build -o promdump-debug -ldflags=" -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
 
     - name: Test promdump
       working-directory: ./promdump
@@ -33,9 +34,10 @@ jobs:
     - name: Compress artifacts
       run: |
         gzip promdump/promdump
+        gzip promdump/promdump-debug
 
     - name: Upload promdump
       uses: actions/upload-artifact@v4
       with:
         name: promdump
-        path: promdump/promdump.gz
+        path: promdump/promdump*.gz

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -26,7 +26,8 @@ jobs:
       # github.ref_name is the tag or branch name
       run: |
         go get
-        CGO_ENABLED=0 go build -ldflags=" -s -w -X 'main.AppVersion=${{ github.ref_name }}' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        CGO_ENABLED=0 go build -ldflags=" -s -w -X 'main.AppVersion=${{ github.ref_name }}' -X 'main.SymbolStatus=STRIPPED' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        CGO_ENABLED=0 go build -o promdump-debug -ldflags=" -X 'main.AppVersion=${{ github.ref_name }}' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
 
     - name: Test promdump
       working-directory: ./promdump
@@ -35,9 +36,10 @@ jobs:
     - name: Compress artifacts
       run: |
         gzip promdump/promdump
+        gzip promdump/promdump-debug
 
     - name: Upload promdump
       uses: actions/upload-artifact@v4
       with:
         name: promdump
-        path: promdump/promdump.gz
+        path: promdump/promdump*.gz

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -26,7 +26,7 @@ jobs:
       # github.ref_name is the tag or branch name
       run: |
         go get
-        CGO_ENABLED=0 go build -ldflags=" -X 'main.AppVersion=${{ github.ref_name }}' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
+        CGO_ENABLED=0 go build -ldflags=" -s -w -X 'main.AppVersion=${{ github.ref_name }}' -X 'main.CommitHash=$(git rev-parse HEAD)' -X 'main.BuildTime=$(date -Iseconds)'" -v ./...
 
     - name: Test promdump
       working-directory: ./promdump

--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -133,9 +133,10 @@ var (
 	// as needed.
 	now = time.Now
 
-	AppVersion = "DEV BUILD"
-	CommitHash = "POPULATED_BY_BUILD"
-	BuildTime  = "POPULATED_BY_BUILD"
+	AppVersion   = "DEV BUILD"
+	SymbolStatus = "NON-STRIPPED"
+	CommitHash   = "POPULATED_BY_BUILD"
+	BuildTime    = "POPULATED_BY_BUILD"
 )
 
 func init() {
@@ -999,7 +1000,7 @@ func main() {
 	}
 	logger, _ = initLogging(logFile)
 
-	verString := fmt.Sprintf("promdump version %v from commit %v built %v\n", AppVersion, CommitHash, BuildTime)
+	verString := fmt.Sprintf("promdump version %v %v from commit %v built %v\n", AppVersion, SymbolStatus, CommitHash, BuildTime)
 
 	if *version {
 		fmt.Printf(verString)


### PR DESCRIPTION
This change reduces the uncompressed size of the `promdump` binary from 14MB to 11MB and the compressed size of the binary from 7MB to 4MB.

The GitHub actions that build `promdump` will now produce two versions of the binary, one with debug symbols and one without. These symbols are only required for analyzing crashes, which are rare in `promdump`.

A `SymbolStatus` variable has been added to the code that can be overridden at build time. The two versions of the binary are differentiated in the version string as STRIPPED vs NON-STRIPPED.